### PR TITLE
Add recurring monthly flows

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/rwc/streamwise/App.kt
+++ b/composeApp/src/commonMain/kotlin/io/rwc/streamwise/App.kt
@@ -8,24 +8,29 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.ionspin.kotlin.bignum.decimal.toBigDecimal
+import io.rwc.streamwise.flows.Fixed
+import io.rwc.streamwise.flows.Monthly
+import io.rwc.streamwise.flows.reifyFlows
 import kotlinx.datetime.LocalDate
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 @Preview
 fun App() {
-  val balances = listOf(
-    DailyBalance(LocalDate(2023, 1, 1), 1000.toBigDecimal()),
-    DailyBalance(LocalDate(2023, 1, 2), 1100.toBigDecimal()),
-    DailyBalance(LocalDate(2023, 1, 3), 1050.toBigDecimal()),
-    DailyBalance(LocalDate(2023, 1, 4), 1200.toBigDecimal()),
-    DailyBalance(LocalDate(2023, 1, 5), 1150.toBigDecimal()),
-    DailyBalance(LocalDate(2023, 1, 6), 1300.toBigDecimal()),
-    DailyBalance(LocalDate(2023, 1, 7), 1250.toBigDecimal()),
-    DailyBalance(LocalDate(2023, 1, 8), 1400.toBigDecimal()),
-    DailyBalance(LocalDate(2023, 1, 9), 1350.toBigDecimal()),
-    DailyBalance(LocalDate(2023, 1, 10), 1500.toBigDecimal()),
+  val flows = listOf(
+    Fixed(LocalDate(2023, 1, 1), 1000.toBigDecimal()),
+    Monthly("ebmud", 5, -100.toBigDecimal()),
+    Monthly("pg&e", -5, -200.toBigDecimal()),
+    Monthly("income", 15, 1000.toBigDecimal()),
+    Monthly("stuff", -7, -500.toBigDecimal()),
+    Monthly("income", 30, 1000.toBigDecimal()),
   )
+  val cash = reifyFlows(flows, LocalDate(2023, 1, 1), LocalDate(2023, 12, 31))
+  var runningTotal = 0.toBigDecimal()
+  val balances = cash.associate {
+    runningTotal += it.amount
+    it.date to runningTotal
+  }
 
   MaterialTheme {
     Column(

--- a/composeApp/src/commonMain/kotlin/io/rwc/streamwise/charting.kt
+++ b/composeApp/src/commonMain/kotlin/io/rwc/streamwise/charting.kt
@@ -66,8 +66,8 @@ fun AxisTitle(title: String, modifier: Modifier = Modifier) {
 @OptIn(ExperimentalKoalaPlotApi::class, ExperimentalTime::class)
 @Composable
 @Suppress("MagicNumber")
-fun TimeSamplePlot(balances: List<DailyBalance>, thumbnail: Boolean, title: String) {
-  val data = balances.map { DefaultPoint(it.date, it.balance) }
+fun TimeSamplePlot(balances: Map<LocalDate, BigDecimal>, thumbnail: Boolean, title: String) {
+  val data = balances.map { (date, balance) -> DefaultPoint(date, balance) }
   val yDataMin = data.minOfOrNull { it.y } ?: 0.toBigDecimal()
   val yDataMax = data.maxOfOrNull { it.y } ?: 1.toBigDecimal()
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ composeMultiplatform = "1.8.1"
 junit = "4.13.2"
 koalaplot = "0.8.0"
 kotlin = "2.1.21"
-kotlinxDatetime = "0.6.0"
+kotlinxDatetime = "0.6.2"
 ktor = "3.1.3"
 logback = "1.5.18"
 

--- a/shared/src/commonMain/kotlin/io/rwc/streamwise/DailyBalance.kt
+++ b/shared/src/commonMain/kotlin/io/rwc/streamwise/DailyBalance.kt
@@ -1,6 +1,0 @@
-package io.rwc.streamwise
-
-import com.ionspin.kotlin.bignum.decimal.BigDecimal
-import kotlinx.datetime.LocalDate
-
-data class DailyBalance(val date: LocalDate, val balance: BigDecimal)

--- a/shared/src/commonMain/kotlin/io/rwc/streamwise/flows/CashFlow.kt
+++ b/shared/src/commonMain/kotlin/io/rwc/streamwise/flows/CashFlow.kt
@@ -1,0 +1,34 @@
+package io.rwc.streamwise.flows
+
+import com.ionspin.kotlin.bignum.decimal.BigDecimal
+import com.ionspin.kotlin.bignum.decimal.toBigDecimal
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.plus
+
+interface CashFlow {
+  fun valueOn(date: LocalDate): BigDecimal
+}
+
+data class Fixed(val date: LocalDate, val amount: BigDecimal) : CashFlow {
+  override fun valueOn(date: LocalDate): BigDecimal {
+    return if (this@Fixed.date == date) {
+      amount
+    } else {
+      0.toBigDecimal()
+    }
+  }
+}
+
+fun reifyFlows(flows: List<CashFlow>, startDate: LocalDate, endDate: LocalDate): List<Fixed> {
+  val cashFlow = mutableListOf<Fixed>()
+
+  var date = startDate
+  while (date <= endDate) {
+    val dayAmount = flows.fold(0.toBigDecimal(), { total, flow -> total + flow.valueOn(date) })
+    cashFlow.add(Fixed(date, dayAmount))
+    date = date.plus(1, DateTimeUnit.DAY)
+  }
+
+  return cashFlow
+}

--- a/shared/src/commonMain/kotlin/io/rwc/streamwise/flows/Monthly.kt
+++ b/shared/src/commonMain/kotlin/io/rwc/streamwise/flows/Monthly.kt
@@ -1,0 +1,84 @@
+package io.rwc.streamwise.flows
+
+import com.ionspin.kotlin.bignum.decimal.BigDecimal
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.Month
+import kotlinx.datetime.number
+import kotlin.math.abs
+
+/**
+ * A simple class to represent a year and month combination.
+ *
+ * @param year The year
+ * @param month The month
+ */
+private class YearMonth(val year: Int, val month: Month) {
+    /**
+     * Returns the last day of the month.
+     *
+     * @return The date representing the last day of the month
+     */
+    fun atEndOfMonth(): LocalDate {
+        val daysInMonth = when (month) {
+            Month.FEBRUARY -> if (isLeapYear(year)) 29 else 28
+            Month.APRIL, Month.JUNE, Month.SEPTEMBER, Month.NOVEMBER -> 30
+            else -> 31
+        }
+        return LocalDate(year, month, daysInMonth)
+    }
+
+    /**
+     * Determines if the given year is a leap year.
+     *
+     * @return True if the year is a leap year, false otherwise
+     */
+    private fun isLeapYear(year: Int): Boolean {
+        return year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
+    }
+}
+
+/**
+ * Implementation of CashFlow that occurs on a specific day of the month.
+ * 
+ * @param dayOffset The day offset (1-indexed). If positive, it's the day from the start of the month.
+ *                  If negative, it's the day from the end of the month.
+ * @param value The value of the cash flow.
+ */
+class Monthly(val name: String, private val dayOffset: Int, private val value: BigDecimal) : CashFlow {
+    init {
+        require(dayOffset != 0) { "Day offset cannot be zero" }
+        require(abs(dayOffset) <= 31) { "Day offset can't be longer than a month" }
+    }
+
+    override fun valueOn(date: LocalDate): BigDecimal {
+        val targetDay = calculateTargetDay(date.month, date.year)
+
+        return if (date.dayOfMonth == targetDay) {
+            value
+        } else {
+            BigDecimal.ZERO
+        }
+    }
+
+    /**
+     * Calculates the target day of the month based on the day offset.
+     * 
+     * @param month The month
+     * @param year The year (needed to determine the number of days in the month)
+     * @return The target day of the month
+     */
+    private fun calculateTargetDay(month: Month, year: Int): Int {
+        val yearMonth = YearMonth(year, month)
+        val lastDayOfMonth = yearMonth.atEndOfMonth()
+
+        return if (dayOffset > 0) {
+            // Positive offset: count from the beginning of the month
+            minOf(dayOffset, lastDayOfMonth.dayOfMonth)
+        } else {
+            // Negative offset: count from the end of the month
+            val daysFromEnd = -dayOffset
+            val targetDay = lastDayOfMonth.dayOfMonth - daysFromEnd + 1
+            maxOf(targetDay, 1)
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/io/rwc/streamwise/flows/FixedTest.kt
+++ b/shared/src/commonTest/kotlin/io/rwc/streamwise/flows/FixedTest.kt
@@ -1,0 +1,69 @@
+package io.rwc.streamwise.flows
+
+import com.ionspin.kotlin.bignum.decimal.BigDecimal
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FixedTest {
+    
+    @Test
+    fun `test valueOn with matching date`() {
+        val date = LocalDate(2023, 5, 15)
+        val amount = BigDecimal.fromInt(1000)
+        val fixed = Fixed(date, amount)
+        
+        // Test with the same date
+        assertEquals(amount, fixed.valueOn(date))
+    }
+    
+    @Test
+    fun `test valueOn with non-matching date`() {
+        val date = LocalDate(2023, 5, 15)
+        val amount = BigDecimal.fromInt(1000)
+        val fixed = Fixed(date, amount)
+        
+        // Test with a different date
+        val differentDate = LocalDate(2023, 5, 16)
+        assertEquals(BigDecimal.ZERO, fixed.valueOn(differentDate))
+    }
+    
+    @Test
+    fun `test valueOn with negative amount`() {
+        val date = LocalDate(2023, 5, 15)
+        val amount = BigDecimal.fromInt(-500)
+        val fixed = Fixed(date, amount)
+        
+        // Test with the same date
+        assertEquals(amount, fixed.valueOn(date))
+        
+        // Test with a different date
+        val differentDate = LocalDate(2023, 5, 16)
+        assertEquals(BigDecimal.ZERO, fixed.valueOn(differentDate))
+    }
+    
+    @Test
+    fun `test valueOn with zero amount`() {
+        val date = LocalDate(2023, 5, 15)
+        val amount = BigDecimal.ZERO
+        val fixed = Fixed(date, amount)
+        
+        // Test with the same date
+        assertEquals(amount, fixed.valueOn(date))
+        
+        // Test with a different date
+        val differentDate = LocalDate(2023, 5, 16)
+        assertEquals(BigDecimal.ZERO, fixed.valueOn(differentDate))
+    }
+    
+    @Test
+    fun `test data class equality`() {
+        val date = LocalDate(2023, 5, 15)
+        val amount = BigDecimal.fromInt(1000)
+        val fixed1 = Fixed(date, amount)
+        val fixed2 = Fixed(date, amount)
+        
+        // Test data class equality
+        assertEquals(fixed1, fixed2)
+    }
+}

--- a/shared/src/commonTest/kotlin/io/rwc/streamwise/flows/MonthlyTest.kt
+++ b/shared/src/commonTest/kotlin/io/rwc/streamwise/flows/MonthlyTest.kt
@@ -1,0 +1,116 @@
+package io.rwc.streamwise.flows
+
+import com.ionspin.kotlin.bignum.decimal.BigDecimal
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class MonthlyTest {
+
+    @Test
+    fun `test positive day offset`() {
+        val value = BigDecimal.fromInt(100)
+        val monthly = Monthly("test", 5, value)
+
+        // Test a date that matches the offset
+        val matchingDate = LocalDate(2023, 3, 5) // March 5, 2023
+        assertEquals(value, monthly.valueOn(matchingDate))
+
+        // Test a date that doesn't match the offset
+        val nonMatchingDate = LocalDate(2023, 3, 6) // March 6, 2023
+        assertEquals(BigDecimal.ZERO, monthly.valueOn(nonMatchingDate))
+    }
+
+    @Test
+    fun `test negative day offset`() {
+        val value = BigDecimal.fromInt(200)
+        val monthly = Monthly("test", -1, value)
+
+        // Test a date that matches the offset in a 31-day month
+        val matchingDateMarch = LocalDate(2023, 3, 31) // March 31, 2023 (last day)
+        assertEquals(value, monthly.valueOn(matchingDateMarch))
+
+        // Test a date that matches the offset in a 30-day month
+        val matchingDateApril = LocalDate(2023, 4, 30) // April 30, 2023 (last day)
+        assertEquals(value, monthly.valueOn(matchingDateApril))
+
+        // Test a date that doesn't match the offset
+        val nonMatchingDate = LocalDate(2023, 3, 30) // March 30, 2023 (second-to-last day)
+        assertEquals(BigDecimal.ZERO, monthly.valueOn(nonMatchingDate))
+    }
+
+    @Test
+    fun `test February in leap year and non-leap year`() {
+        val value = BigDecimal.fromInt(300)
+        val monthly = Monthly("test", 29, value)
+
+        // Test February 29 in a leap year
+        val leapYearFeb29 = LocalDate(2020, 2, 29) // February 29, 2020 (leap year)
+        assertEquals(value, monthly.valueOn(leapYearFeb29))
+
+        // Test February 28 in a non-leap year (should match since February only has 28 days)
+        val nonLeapYearFeb28 = LocalDate(2023, 2, 28) // February 28, 2023 (non-leap year)
+        assertEquals(value, monthly.valueOn(nonLeapYearFeb28))
+
+        // Test February 28 in a leap year (should not match)
+        val leapYearFeb28 = LocalDate(2020, 2, 28) // February 28, 2020 (leap year)
+        assertEquals(BigDecimal.ZERO, monthly.valueOn(leapYearFeb28))
+    }
+
+    @Test
+    fun `test negative day offset in February`() {
+        val value = BigDecimal.fromInt(400)
+        val monthly = Monthly("test", -1, value)
+
+        // Test last day of February in a leap year
+        val leapYearFeb29 = LocalDate(2020, 2, 29) // February 29, 2020 (leap year)
+        assertEquals(value, monthly.valueOn(leapYearFeb29))
+
+        // Test last day of February in a non-leap year
+        val nonLeapYearFeb28 = LocalDate(2023, 2, 28) // February 28, 2023 (non-leap year)
+        assertEquals(value, monthly.valueOn(nonLeapYearFeb28))
+    }
+
+    @Test
+    fun `test day offset exceeding month length`() {
+        val value = BigDecimal.fromInt(500)
+        val monthly = Monthly("test", 31, value)
+
+        // Test a 31-day month
+        val march31 = LocalDate(2023, 3, 31) // March 31, 2023
+        assertEquals(value, monthly.valueOn(march31))
+
+        // Test a 30-day month (should match on the last day)
+        val april30 = LocalDate(2023, 4, 30) // April 30, 2023
+        assertEquals(value, monthly.valueOn(april30))
+
+        // Test February in a non-leap year (should match on the last day)
+        val feb28 = LocalDate(2023, 2, 28) // February 28, 2023
+        assertEquals(value, monthly.valueOn(feb28))
+    }
+
+    @Test
+    fun `test zero day offset throws exception`() {
+        val value = BigDecimal.fromInt(600)
+
+        // Test that constructor throws an exception for zero day offset
+        assertFailsWith<IllegalArgumentException> {
+            Monthly("test", 0, value)
+        }
+    }
+
+    @Test
+    fun `test day offset longer than month throws exception`() {
+        val value = BigDecimal.fromInt(700)
+
+        // Test that constructor throws an exception for day offset longer than 31 days
+        assertFailsWith<IllegalArgumentException> {
+            Monthly("test", 32, value)
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            Monthly("test", -32, value)
+        }
+    }
+}


### PR DESCRIPTION
Add recurring monthly cash flows, as demonstrated here.

<img width="1448" alt="Screenshot 2025-06-11 at 10 22 10 PM" src="https://github.com/user-attachments/assets/4623521a-cc5b-401e-8258-8a2ea26ee760" />

Note the positive & negative month offsets.